### PR TITLE
Support alexapy JSON .cookies files

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Ensure you have a `.env` file in the project root with the following content:
 ```yaml
 HA_WEBHOOK_URL=http://192.168.1.254:8123/api/webhook/--8v4O3JZHbRRPMS93nspLfIS
 AMAZON_URL=https://www.amazon.fr
-COOKIE_PATH=/cookie.pickle
+COOKIE_PATH=/cookie.cookies
 LOG_LEVEL=INFO
 ```
 
@@ -70,9 +70,13 @@ services:
       - .env
     volumes:
       - .:/usr/src/app
-      - /srv/home-assistant/config/.storage/alexa_media.EMAIL.pickle:/cookie.pickle:ro
+      - /srv/home-assistant/config/.storage/alexa_media.EMAIL.cookies:/cookie.cookies:ro
     command: python ./main.py
 ```
+
+Recent `alexa_media_player` releases can generate a JSON `.cookies` file instead of the older
+pickled `.pickle` file. This project should point `COOKIE_PATH` at the `.cookies` file when you
+are using `alexa_media_player` `v5.15.6` or newer.
 
 ### 4. Run
 
@@ -91,7 +95,7 @@ docker-compose up
 pip3 install -r requirements.txt
 export HA_WEBHOOK_URL=http://192.168.1.254:8123/api/webhook/--8v4O3JZHbRRPMS93nspLfIS
 export AMAZON_URL=https://www.amazon.fr
-export COOKIE_PATH=/cookie.pickle
+export COOKIE_PATH=/cookie.cookies
 export LOG_LEVEL=INFO
 python3 main.py
 ```

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import requests
 import pickle
+import json
 from dotenv import load_dotenv
 from http.cookies import SimpleCookie
 from http import cookies
@@ -79,15 +80,45 @@ def initialize_environment_variables():
 def load_cookies_from_file(cookie_file_path):
     try:
         with open(cookie_file_path, 'rb') as cookie_file:
-            cookies = pickle.load(cookie_file)
-        if isinstance(cookies, defaultdict) and all(
-                isinstance(v, SimpleCookie) for v in cookies.values()):
+            raw_cookie_file = cookie_file.read()
+
+        loaded_cookies = None
+        try:
+            loaded_cookies = json.loads(raw_cookie_file.decode('utf-8'))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            loaded_cookies = pickle.loads(raw_cookie_file)
+
+        if (
+            isinstance(loaded_cookies, dict)
+            and loaded_cookies.get('format') == 'alexapy.cookies'
+        ):
             cookie_dict = {}
-            for domain, simple_cookie in cookies.items():
+            for cookie in loaded_cookies.get('cookies', []):
+                if not isinstance(cookie, dict):
+                    continue
+                name = cookie.get('name')
+                value = cookie.get('value')
+                if name and value is not None:
+                    cookie_dict[str(name)] = str(value)
+            return cookie_dict
+
+        if isinstance(loaded_cookies, defaultdict) and all(
+                isinstance(v, SimpleCookie) for v in loaded_cookies.values()):
+            cookie_dict = {}
+            for domain, simple_cookie in loaded_cookies.items():
                 for key, morsel in simple_cookie.items():
                     cookie_dict[key] = morsel.value
             return cookie_dict
-        return cookies
+
+        if isinstance(loaded_cookies, dict):
+            return loaded_cookies
+
+        logger.error(
+            "Unsupported cookie format in %s: %s",
+            cookie_file_path,
+            type(loaded_cookies).__name__,
+        )
+        return None
     except Exception as err:
         logger.error(f"Failed to load cookies from {cookie_file_path}: {err}")
         return None


### PR DESCRIPTION
## What changed

This updates `alexa2ha` to accept the newer JSON `.cookies` format written by recent `alexapy` / `alexa_media_player` releases, while preserving support for the legacy pickled cookie format.

It also updates the README examples to point at `.cookies` instead of `.pickle` for newer Alexa Media installs.

## Why

Users on newer Alexa Media versions can end up with a `.cookies` file and a `.pickle` directory instead of the old single `.pickle` file. The existing loader always calls `pickle.load(...)`, which fails immediately on the JSON cookie file with an error like `invalid load key, '{'`.

## Impact

This lets `alexa2ha` work with both:

- legacy pickled cookie files
- current `alexapy.cookies` JSON cookie files

It also reduces setup confusion by documenting the right bind mount and `COOKIE_PATH` value for current installs.

## Validation

- verified the root-cause change in `alexa_media_player` `v5.15.6`, which bumped `alexapy` to `1.29.25`
- validated local Python syntax with `python -m py_compile main.py`
- confirmed the new loader recognizes the `alexapy.cookies` serialized format and extracts cookie name/value pairs

## Summary by Sourcery

Add support for both JSON-based alexapy .cookies files and legacy pickled cookie formats when loading Alexa cookies.

New Features:
- Allow loading cookies from alexapy JSON .cookies files in addition to legacy pickle files.

Enhancements:
- Improve cookie loader robustness with clearer handling of multiple cookie formats and error logging.

Documentation:
- Update README examples and guidance to use .cookies paths and document behavior for newer alexa_media_player releases.